### PR TITLE
Allow installing aliases with `git install <alias>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ you want git_aliases installed and then execute the following commands.
 By default, all aliases are installed. If you only want to install some aliases,
 use these commands:
 
-	./git_aliases.rb uninstall all # To uninstall the default aliases
-	./git_aliases.rb install <alias 1> <alais 2> ...
+	git uninstall all # To uninstall the default aliases
+	git install <alias 1> <alias 2> ...
 
 Note: Currently, "all" is treated like a normal alias. As a result, you can't
 uninstall individual aliases that were installed with "all". Instead, you have

--- a/aliases/all.gitconfig
+++ b/aliases/all.gitconfig
@@ -26,3 +26,5 @@
 	path = view-conflicts.gitconfig
 	path = view-diff.gitconfig
 	path = split.gitconfig
+	path = install.gitconfig
+	path = uninstall.gitconfig

--- a/aliases/install.gitconfig
+++ b/aliases/install.gitconfig
@@ -1,0 +1,2 @@
+[alias]
+  install = "!ruby `git config alias-config.alias-root`/lib/git_aliases/commands/install.rb"

--- a/aliases/uninstall.gitconfig
+++ b/aliases/uninstall.gitconfig
@@ -1,0 +1,2 @@
+[alias]
+  uninstall = "!ruby `git config alias-config.alias-root`/lib/git_aliases/commands/uninstall.rb"

--- a/lib/git_aliases/commands/install.rb
+++ b/lib/git_aliases/commands/install.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require_relative '../../git_aliases'
+require 'git_aliases/installation'
+
+installation = GitAliases::Installation.this
+
+if ARGV.length < 1
+  puts 'Usage: git install <alias> [<alias>...]'
+  exit false
+end
+
+ARGV.each do |new_alias|
+  installation.install_alias(new_alias)
+end

--- a/lib/git_aliases/commands/uninstall.rb
+++ b/lib/git_aliases/commands/uninstall.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require_relative '../../git_aliases'
+require 'git_aliases/installation'
+
+installation = GitAliases::Installation.this
+
+if ARGV.length < 1
+  puts 'Usage: git uninstall <alias> [<alias>...]'
+  exit false
+end
+
+ARGV.each do |new_alias|
+  installation.uninstall_alias(new_alias)
+end

--- a/lib/git_aliases/installation.rb
+++ b/lib/git_aliases/installation.rb
@@ -35,6 +35,8 @@ module GitAliases
     def install
       install_basics
       install_alias("all")
+      install_alias("install")
+      install_alias("uninstall")
     end
 
     def uninstall

--- a/lib/git_aliases/installation.rb
+++ b/lib/git_aliases/installation.rb
@@ -3,6 +3,10 @@ require "git_aliases/git/config"
 
 module GitAliases
   class Installation
+    def self.this
+      new(File.expand_path(File.join(File.dirname(__FILE__), "..", "..")))
+    end
+
     def initialize(root, options={})
       @root = root
       @git_config = options[:git_config] || Git::Config.new


### PR DESCRIPTION
Add aliases for installing and uninstalling aliases, so users don't have to use the installer script directly.
